### PR TITLE
Restructure docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .php_cs.cache
 nbproject
 composer.lock
+docs/html

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ You can install Prooph Snapshot Store via composer by adding `"prooph/snapshot-s
 
 - Ask questions on Stack Overflow tagged with [#prooph](https://stackoverflow.com/questions/tagged/prooph).
 - File issues at [https://github.com/prooph/snapshot-store/issues](https://github.com/prooph/snapshot-store/issues).
+- Say hello in the [prooph gitter](https://gitter.im/prooph/improoph) chat.
 
 ## Contribute
 

--- a/composer.json
+++ b/composer.json
@@ -61,10 +61,12 @@
     "scripts": {
         "check": [
             "@cs",
-            "@test"
+            "@test",
+            "@docheader"
         ],
         "cs": "php-cs-fixer fix -v --diff --dry-run",
         "cs-fix": "php-cs-fixer fix -v --diff",
+        "docheader": "docheader check src/ tests/",
         "test": "phpunit"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",
+        "phpspec/prophecy": "^1.7",
         "prooph/php-cs-fixer-config": "^0.1.1",
         "satooshi/php-coveralls": "^1.0",
         "prooph/bookdown-template": "^0.2.3",

--- a/docs/bookdown.json
+++ b/docs/bookdown.json
@@ -2,7 +2,10 @@
   "title": "Snapshot Store",
   "content": [
     {"snapshot_store": "snapshot_store.md"},
-    {"mongodb_snapshot_store": "https://raw.githubusercontent.com/prooph/mongodb-snapshot-store/master/docs/bookdown.json"}
+    {"pdo_snapshot_store": "https://raw.githubusercontent.com/prooph/pdo-snapshot-store/master/docs/bookdown.json"},
+    {"mongodb_snapshot_store": "https://raw.githubusercontent.com/prooph/mongodb-snapshot-store/master/docs/bookdown.json"},
+    {"memcached_snapshot_store": "https://raw.githubusercontent.com/prooph/memcached-snapshot-store/master/docs/bookdown.json"},
+    {"arangodb_snapshot_store": "https://raw.githubusercontent.com/prooph/arangodb-snapshot-store/master/docs/bookdown.json"}
   ],
   "tocDepth": 1,
   "numbering": false,

--- a/docs/bookdown.json
+++ b/docs/bookdown.json
@@ -1,8 +1,8 @@
 {
-  "title": "Prooph Snapshot Store",
+  "title": "Snapshot Store",
   "content": [
     {"intro": "../README.md"},
-    {"snapshots": "snapshots.md"}
+    {"snapshots": "snapshot_store.md"}
   ],
   "target": "./html",
   "template": "../vendor/prooph/bookdown-template/templates/main.php"

--- a/docs/bookdown.json
+++ b/docs/bookdown.json
@@ -4,6 +4,8 @@
     {"intro": "../README.md"},
     {"snapshots": "snapshot_store.md"}
   ],
+  "tocDepth": 1,
+  "numbering": false,
   "target": "./html",
   "template": "../vendor/prooph/bookdown-template/templates/main.php"
 }

--- a/docs/bookdown.json
+++ b/docs/bookdown.json
@@ -1,8 +1,8 @@
 {
   "title": "Snapshot Store",
   "content": [
-    {"intro": "../README.md"},
-    {"snapshots": "snapshot_store.md"}
+    {"snapshot_store": "snapshot_store.md"},
+    {"mongodb_snapshot_store": "https://raw.githubusercontent.com/prooph/mongodb-snapshot-store/master/docs/bookdown.json"}
   ],
   "tocDepth": 1,
   "numbering": false,

--- a/docs/snapshot_store.md
+++ b/docs/snapshot_store.md
@@ -1,14 +1,12 @@
-# Snapshots
+# Overview
 
-One of the counter-arguments against Event-Sourcing you might heard about is that replaying events takes too much time.
+Simple and lightweight snapshot store that works together with `prooph/event-sourcing` to speed up loading of aggregates.
 
-Replaying 20 events for an aggregate is fast, 50 is ok, but 100 events and more become slow depending on the data of the events and the operations needed to replay them.
-A DDD rule of thumb says aggregates should be kept small. Keeping that in mind you should be fine with 50 events per aggregate
-in most cases.
+## Installation
 
-## But my aggregates record tons of events!
-If aggregate reconstitution gets slow you can add an additional layer to the system which
-is capable of providing aggregate snapshots.
+```bash
+composer require prooph/snapshot-store
+```
 
 ## Creating snapshots from event streams
 

--- a/src/CallbackSerializer.php
+++ b/src/CallbackSerializer.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/snapshot-store.
- * (c) 2016-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2017-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2017-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/CompositeSnapshotStoreFactory.php
+++ b/src/Container/CompositeSnapshotStoreFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/snapshot-store.
- * (c) 2016-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2017-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2017-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/snapshot-store.
- * (c) 2016-2017 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2017-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2017-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/CompositeSnapshotStoreFactoryTest.php
+++ b/tests/Container/CompositeSnapshotStoreFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * This file is part of the prooph/memcached-snapshot-store.
+ * This file is part of the prooph/snapshot-store.
  * (c) 2017-2017 prooph software GmbH <contact@prooph.de>
  * (c) 2017-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace ProophTest\SnapshotStore\Container;
 
-use Memcached;
 use PHPUnit\Framework\TestCase;
 use Prooph\SnapshotStore\CompositeSnapshotStore;
 use Prooph\SnapshotStore\Container\CompositeSnapshotStoreFactory;

--- a/tests/Container/CompositeSnapshotStoreFactoryTest.php
+++ b/tests/Container/CompositeSnapshotStoreFactoryTest.php
@@ -14,9 +14,8 @@ namespace ProophTest\SnapshotStore\Container;
 
 use Memcached;
 use PHPUnit\Framework\TestCase;
-use Prooph\SnapshotStore\CallbackSerializer;
-use Prooph\SnapshotStore\Container\CompositeSnapshotStoreFactory;
 use Prooph\SnapshotStore\CompositeSnapshotStore;
+use Prooph\SnapshotStore\Container\CompositeSnapshotStoreFactory;
 use Prooph\SnapshotStore\SnapshotStore;
 use Psr\Container\ContainerInterface;
 


### PR DESCRIPTION
According to https://github.com/prooph/proophessor/issues/38#issuecomment-336200542

- shorter headlines
- introduction instead of using entire README (better overview while browsing through the docs)