### PR TITLE
Support PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,26 @@ matrix:
     - php: 7.2
       env:
         - DEPENDENCIES="--prefer-lowest --prefer-stable"
+    - php: 7.3
+      env:
+        - DEPENDENCIES=""
+        - TEST_COVERAGE=true
+    - php: 7.3
+      env:
+        - DEPENDENCIES="--prefer-lowest --prefer-stable"
+    - php: 7.4
+      env:
+        - DEPENDENCIES=""
+        - TEST_COVERAGE=true
+    - php: 7.4
+      env:
+        - DEPENDENCIES="--prefer-lowest --prefer-stable"
+    - php: 8.0
+      env:
+        - DEPENDENCIES=""
+    - php: 8.0
+      env:
+        - DEPENDENCIES="--prefer-lowest --prefer-stable"
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8.0",
         "prooph/common" : "^4.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
-        "phpspec/prophecy": "^1.7",
-        "prooph/php-cs-fixer-config": "^0.3",
+        "phpunit/phpunit": "^6.0 || ^9.3",
+        "phpspec/prophecy": "^1.9",
+        "prooph/php-cs-fixer-config": "^0.3 || ^0.4",
         "satooshi/php-coveralls": "^1.0",
         "prooph/bookdown-template": "^0.2.3",
         "psr/container": "^1.0",

--- a/src/CallbackSerializer.php
+++ b/src/CallbackSerializer.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/snapshot-store.
- * (c) 2017-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2017-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2017-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2017-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/CompositeSnapshotStore.php
+++ b/src/CompositeSnapshotStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/snapshot-store.
- * (c) 2017-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2017-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2017-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2017-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/CompositeSnapshotStoreFactory.php
+++ b/src/Container/CompositeSnapshotStoreFactory.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/snapshot-store.
- * (c) 2017-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2017-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2017-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2017-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/InMemorySnapshotStore.php
+++ b/src/InMemorySnapshotStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/snapshot-store.
- * (c) 2017-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2017-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2017-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2017-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/snapshot-store.
- * (c) 2017-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2017-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2017-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2017-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/snapshot-store.
- * (c) 2017-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2017-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2017-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2017-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/SnapshotStore.php
+++ b/src/SnapshotStore.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/snapshot-store.
- * (c) 2017-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2017-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2017-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2017-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/CallbackSerializerTest.php
+++ b/tests/CallbackSerializerTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/snapshot-store.
- * (c) 2017-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2017-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2017-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2017-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/CompositeSnapshotStoreTest.php
+++ b/tests/CompositeSnapshotStoreTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/snapshot-store.
- * (c) 2017-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2017-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2017-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2017-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/CompositeSnapshotStoreFactoryTest.php
+++ b/tests/Container/CompositeSnapshotStoreFactoryTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/snapshot-store.
- * (c) 2017-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2017-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2017-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2017-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/InMemorySnapshotStoreTest.php
+++ b/tests/InMemorySnapshotStoreTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/snapshot-store.
- * (c) 2017-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2017-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2017-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2017-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/SnapshotTest.php
+++ b/tests/SnapshotTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of prooph/snapshot-store.
- * (c) 2017-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2017-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2017-2021 prooph software GmbH <contact@prooph.de>
+ * (c) 2017-2021 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.


### PR DESCRIPTION
Hello, first pull request here, please be patient.
I upgraded `composer.json` to allow compatibility with PHP 8.
My goal is to allow allow `prooph/event-sourcing` compatibility with PHP 8 as well in few days.
Test files have been updated with new Prophecy trait.
`composer check` on PHP 8.0.2 works flawlessly.